### PR TITLE
[Forwardport] Changes for : enable creditmemo feature for zero order total.

### DIFF
--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -13,6 +13,7 @@ use Magento\Sales\Api\Data\CreditmemoInterface;
 use Magento\Sales\Model\AbstractModel;
 use Magento\Sales\Model\EntityInterface;
 use Magento\Sales\Model\Order\InvoiceFactory;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 
 /**
  * Order creditmemo model
@@ -39,6 +40,11 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
     const REPORT_DATE_TYPE_ORDER_CREATED = 'order_created';
 
     const REPORT_DATE_TYPE_REFUND_CREATED = 'refund_created';
+
+    /**
+     * Allow Zero Grandtotal for Creditmemo path
+     */
+    const XML_PATH_ALLOW_ZERO_GRANDTOTAL = 'sales/zerograndtotal_creditmemo/allow_zero_grandtotal';
 
     /**
      * Identifier for order history item
@@ -120,6 +126,11 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
     private $invoiceFactory;
 
     /**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
      * @param \Magento\Framework\Model\Context $context
      * @param \Magento\Framework\Registry $registry
      * @param \Magento\Framework\Api\ExtensionAttributesFactory $extensionFactory
@@ -136,6 +147,7 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
      * @param \Magento\Framework\Data\Collection\AbstractDb $resourceCollection
      * @param array $data
      * @param InvoiceFactory $invoiceFactory
+     * @param ScopeConfigInterface $scopeConfig
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -151,6 +163,7 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
         \Magento\Sales\Model\Order\Creditmemo\CommentFactory $commentFactory,
         \Magento\Sales\Model\ResourceModel\Order\Creditmemo\Comment\CollectionFactory $commentCollectionFactory,
         PriceCurrencyInterface $priceCurrency,
+        ScopeConfigInterface $scopeConfig,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
         array $data = [],
@@ -164,6 +177,7 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
         $this->_commentFactory = $commentFactory;
         $this->_commentCollectionFactory = $commentCollectionFactory;
         $this->priceCurrency = $priceCurrency;
+        $this->scopeConfig = $scopeConfig;
         $this->invoiceFactory = $invoiceFactory ?: ObjectManager::getInstance()->get(InvoiceFactory::class);
         parent::__construct(
             $context,
@@ -625,6 +639,17 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
     public function isValidGrandTotal()
     {
         return !($this->getGrandTotal() <= 0 && !$this->getAllowZeroGrandTotal());
+    }
+
+    /**
+     * @return bool
+     */
+
+    public function getAllowZeroGrandTotal()
+    {
+        $isAllowed = $this->scopeConfig->getValue(self::XML_PATH_ALLOW_ZERO_GRANDTOTAL,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        return $isAllowed;
     }
 
     /**

--- a/app/code/Magento/Sales/Model/Order/Creditmemo.php
+++ b/app/code/Magento/Sales/Model/Order/Creditmemo.php
@@ -638,14 +638,14 @@ class Creditmemo extends AbstractModel implements EntityInterface, CreditmemoInt
      */
     public function isValidGrandTotal()
     {
-        return !($this->getGrandTotal() <= 0 && !$this->getAllowZeroGrandTotal());
+        return !($this->getGrandTotal() <= 0 && !$this->hasAllowZeroGrandTotal());
     }
 
     /**
      * @return bool
      */
 
-    public function getAllowZeroGrandTotal()
+    public function hasAllowZeroGrandTotal()
     {
         $isAllowed = $this->scopeConfig->getValue(self::XML_PATH_ALLOW_ZERO_GRANDTOTAL,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE);

--- a/app/code/Magento/Sales/etc/adminhtml/system.xml
+++ b/app/code/Magento/Sales/etc/adminhtml/system.xml
@@ -48,6 +48,13 @@
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>
+            <group id="zerograndtotal_creditmemo" translate="label" type="text" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Allow Zero GrandTotal</label>
+                <field id="allow_zero_grandtotal" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Allow Zero GrandTotal for Creditmemo</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
+            </group>
             <group id="identity" translate="label" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Invoice and Packing Slip Design</label>
                 <field id="logo" translate="label comment" type="image" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/app/code/Magento/Sales/etc/config.xml
+++ b/app/code/Magento/Sales/etc/config.xml
@@ -18,6 +18,9 @@
             <reorder>
                 <allow>1</allow>
             </reorder>
+            <zerograndtotal_creditmemo>
+                <allow_zero_grandtotal>1</allow_zero_grandtotal>
+            </zerograndtotal_creditmemo>
             <minimum_order>
                 <tax_including>1</tax_including>
             </minimum_order>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/15742
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
When customer place an order of zero ordertotal using Zero Subtotal Checkout Payment method and Admin create an invoice - order goes into Processing. After we can't cancel order. 

At such scenario, requirement comes to create creditmemo and return ordered item back in stock.
Magento doesn't allow to create a creditmemo for zero order total. So creating credit memo is required to return ordered items back in stock.

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#13153 : Credit memo for orders with zero TotalPaid

### Manual testing scenarios
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. Place an order of Zero amount using Zero Subtotal Checkout Payment method.
2. Create an invoice for that order.
3. As per Magento behaviour, we can't see Credit Memo Option for Zero Total Order.
4. But Now, you can see 'Credit Memo' option, create credit memo for that order and return item back to stock.
5. We can check same steps for Order of amount greater than zero, It will work proper for them too.

### Actual Result
For Zero Order Total, we can't see Credit Memo Option Available, and so we are unable to generate it.
![actual-result](https://user-images.githubusercontent.com/39254899/40906678-253a0eaa-67ff-11e8-8ed2-9a9375bc47ba.png)


### Expected Result
One should be able to generate Credit Memo even for Zero OrderTotal. 
![expected-result](https://user-images.githubusercontent.com/39254899/40906693-2f66f19a-67ff-11e8-8b0e-383c9114bae9.png)


### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
